### PR TITLE
Add github workflow to check scala code is formatted

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,10 +38,10 @@ jobs:
         env:
           FOSSA_API_KEY: "${{secrets.FOSSA_API_KEY}}"
 
-      - name: Code style check and binary-compatibility check
+      - name: Binary-compatibility check
         run: |-
           cp .jvmopts-ghactions .jvmopts
-          sbt scalafmtCheckAll scalafmtSbtCheck headerCheckAll grpcVersionSyncCheck googleProtobufVersionSyncCheck +mimaReportBinaryIssues
+          sbt headerCheckAll grpcVersionSyncCheck googleProtobufVersionSyncCheck +mimaReportBinaryIssues
 
   compile-benchmarks:
     name: Compile Benchmarks

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,24 @@
+name: Scalafmt
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    name: Code is formatted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v2
+        with:
+          version: '3.6.1'
+          arguments: '--list --mode diff-ref=origin/main'

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -5,7 +5,6 @@ import sbt._
 import sbt.plugins.JvmPlugin
 import akka.grpc.Dependencies.Versions.{ scala212, scala213 }
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys.projectInfoVersion
-import org.scalafmt.sbt.ScalafmtPlugin.autoImport.scalafmtOnCompile
 import com.typesafe.tools.mima.plugin.MimaKeys._
 import sbtprotoc.ProtocPlugin.autoImport.PB
 import xerial.sbt.Sonatype
@@ -75,6 +74,5 @@ object Common extends AutoPlugin {
     apiURL := Some(url(s"https://doc.akka.io/api/akka-grpc/${projectInfoVersion.value}/akka/grpc/index.html")),
     (Test / testOptions) += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
     crossScalaVersions := Seq(scala212, scala213),
-    mimaReportSignatureProblems := true,
-    scalafmtOnCompile := true)
+    mimaReportSignatureProblems := true)
 }


### PR DESCRIPTION
Similar to pekko core, replaces the sbt scalafmt check with a github actions one. Also removes the `scalafmtOnCompile` check because it is now unnecessary (and it also doesn't play well with IDE's).