### PR TITLE
Properly remove branch protection

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,6 +26,9 @@ github:
     squash:  true
     merge:   false
     rebase:  true
+
+  github:
+    protected_branches: ~
     
 notifications:
   commits:              commits@pekko.apache.org


### PR DESCRIPTION
This should properly remove branch protection (see https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-Branchprotection)