### PR TITLE
Fix tests due to not setting version correctly for Gradle

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -159,7 +159,7 @@ jobs:
           cp .jvmopts-ghactions .jvmopts
           sbt akka-grpc-codegen/publishM2 akka-grpc-scalapb-protoc-plugin/publishM2 +akka-grpc-runtime/publishM2
           cd gradle-plugin
-          ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace
+          ./gradlew clean publishToMavenLocal --console=plain --info --stacktrace -Dakka.grpc.project.version=$(cat ~/.version | sed -e s/-SNAPSHOT//)
           find ~/.m2 | grep gradle
 
       - name: Test Gradle Java ${{ matrix.SCALA_VERSION }}


### PR DESCRIPTION
So I managed to fix the CI issues behind pekko-grpc tests not passing.

As correctly stated at https://github.com/apache/incubator-pekko-grpc/issues/17#issuecomment-1427881150 the `forked-from-akka` tag was causing issues and to solve this problem I just pushed a `v0.0.0` tag to main.

There was however another additional problem as can been seen from the PR in one case we were forgetting to set the gradle version correctly. I believe that this is an oversight and the reason why it wasn't a problem in the context of Akka is that if you don't do `-Dakka.grpc.project.version=$(cat ~/.version | sed -e s/-SNAPSHOT//)` then it just defaults to the main version derived from the git tag. In the case of Akka this would have worked because there would have been actual releases of that version which would have allowed `./gradlew` to load fine however in our case there is no such release of pekko-grpc v0.0.0.

Pinging @raboof and @jrudolph incase I might have missed something or causing some regression I am not aware of.

Resolves: https://github.com/apache/incubator-pekko-grpc/issues/18
Resolves: https://github.com/apache/incubator-pekko-grpc/issues/17