### PR TITLE
Remove duplicate META-INF license entry

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,6 @@ lazy val runtime = Project(id = "runtime", base = file("runtime"))
     mimaFailOnNoPrevious := true,
     mimaPreviousArtifacts := Set.empty, // temporarily disable mima checks
     AutomaticModuleName.settings("pekko.grpc.runtime"),
-    MetaInfLicenseNoticeCopy.settings,
     ReflectiveCodeGen.generatedLanguages := Seq("Scala"),
     ReflectiveCodeGen.extraGenerators := Seq("ScalaMarshallersCodeGenerator"),
     PB.protocVersion := Dependencies.Versions.googleProtobuf)
@@ -89,7 +88,6 @@ lazy val scalapbProtocPlugin = Project(id = "scalapb-protoc-plugin", base = file
   .settings(
     crossScalaVersions := Dependencies.Versions.CrossScalaForPlugin,
     scalaVersion := Dependencies.Versions.CrossScalaForPlugin.head)
-  .settings(MetaInfLicenseNoticeCopy.settings)
   .settings(addArtifact(Compile / assembly / artifact, assembly))
   .settings(addArtifact(Artifact(pekkoGrpcProtocPluginId, "bat", "bat", "bat"), mkBatAssemblyTask))
   .enablePlugins(ReproducibleBuildsPlugin)
@@ -104,7 +102,6 @@ lazy val mavenPlugin = Project(id = "maven-plugin", base = file("maven-plugin"))
     crossPaths := false,
     crossScalaVersions := Dependencies.Versions.CrossScalaForPlugin,
     scalaVersion := Dependencies.Versions.CrossScalaForPlugin.head)
-  .settings(MetaInfLicenseNoticeCopy.settings)
   .dependsOn(codegen)
 
 lazy val sbtPlugin = Project(id = "sbt-plugin", base = file("sbt-plugin"))
@@ -127,7 +124,6 @@ lazy val sbtPlugin = Project(id = "sbt-plugin", base = file("sbt-plugin"))
   .settings(
     crossScalaVersions := Dependencies.Versions.CrossScalaForPlugin,
     scalaVersion := Dependencies.Versions.CrossScalaForPlugin.head)
-  .settings(MetaInfLicenseNoticeCopy.settings)
   .dependsOn(codegen)
 
 lazy val interopTests = Project(id = "interop-tests", base = file("interop-tests"))
@@ -167,7 +163,6 @@ lazy val interopTests = Project(id = "interop-tests", base = file("interop-tests
         .dependsOn(Compile / products)
         .evaluated
     })))
-  .settings(MetaInfLicenseNoticeCopy.settings)
 
 lazy val benchmarks = Project(id = "benchmarks", base = file("benchmarks"))
   .dependsOn(runtime)
@@ -178,7 +173,6 @@ lazy val benchmarks = Project(id = "benchmarks", base = file("benchmarks"))
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := Dependencies.Versions.CrossScalaForLib.head,
     (publish / skip) := true)
-  .settings(MetaInfLicenseNoticeCopy.settings)
 
 lazy val docs = Project(id = "docs", base = file("docs"))
 // Make sure code generation is run:
@@ -235,7 +229,6 @@ lazy val pluginTesterScala = Project(id = "plugin-tester-scala", base = file("pl
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := scala212,
     ReflectiveCodeGen.codeGeneratorSettings ++= Seq("flat_package", "server_power_apis"))
-  .settings(MetaInfLicenseNoticeCopy.settings)
   .pluginTestingSettings
 
 lazy val pluginTesterJava = Project(id = "plugin-tester-java", base = file("plugin-tester-java"))
@@ -249,7 +242,6 @@ lazy val pluginTesterJava = Project(id = "plugin-tester-java", base = file("plug
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := scala212,
     ReflectiveCodeGen.codeGeneratorSettings ++= Seq("server_power_apis"))
-  .settings(MetaInfLicenseNoticeCopy.settings)
   .pluginTestingSettings
 
 lazy val root = Project(id = "pekko-grpc", base = file("."))

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -8,7 +8,6 @@ import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys.projectInf
 import com.typesafe.tools.mima.plugin.MimaKeys._
 import sbtprotoc.ProtocPlugin.autoImport.PB
 import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
-import SonatypeApachePlugin.autoImport.apacheSonatypeDisclaimerFile
 
 object Common extends AutoPlugin {
   override def trigger = allRequirements
@@ -29,8 +28,7 @@ object Common extends AutoPlugin {
         "Contributors",
         "dev@pekko.apache.org",
         url("https://github.com/apache/incubator-pekko-grpc/graphs/contributors")),
-      description := "Apache Pekko gRPC - Support for building streaming gRPC servers and clients on top of Pekko Streams.",
-      apacheSonatypeDisclaimerFile := Some((LocalRootProject / baseDirectory).value / "DISCLAIMER"))
+      description := "Apache Pekko gRPC - Support for building streaming gRPC servers and clients on top of Pekko Streams.")
 
   override lazy val projectSettings = Seq(
     projectInfoVersion := (if (isSnapshot.value) "snapshot" else version.value),

--- a/project/MetaInfLicenseNoticeCopy.scala
+++ b/project/MetaInfLicenseNoticeCopy.scala
@@ -9,23 +9,19 @@
 
 import sbt.Keys._
 import sbt._
+import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
+import SonatypeApachePlugin.autoImport.apacheSonatypeDisclaimerFile
 
 /**
  * Copies LICENSE and NOTICE files into jar META-INF dir
  */
-object MetaInfLicenseNoticeCopy {
+object MetaInfLicenseNoticeCopy extends AutoPlugin {
 
-  val settings: Seq[Setting[_]] = inConfig(Compile)(
-    Seq(
-      resourceGenerators += copyFileToMetaInf(resourceManaged, "LICENSE"),
-      resourceGenerators += copyFileToMetaInf(resourceManaged, "NOTICE"),
-      resourceGenerators += copyFileToMetaInf(resourceManaged, "DISCLAIMER")))
+  override def trigger = allRequirements
 
-  def copyFileToMetaInf(dir: SettingKey[File], fileName: String) = Def.task[Seq[File]] {
-    val fromFile = (LocalRootProject / baseDirectory).value / fileName
-    val toFile = resourceManaged.value / "META-INF" / fileName
-    IO.copyFile(fromFile, toFile)
-    Seq(toFile)
-  }
+  override def requires = SonatypeApachePlugin
+
+  override lazy val projectSettings = Seq(
+    apacheSonatypeDisclaimerFile := Some((LocalRootProject / baseDirectory).value / "DISCLAIMER"))
 
 }


### PR DESCRIPTION
This PR solves the bug that was revealed in https://github.com/apache/incubator-pekko-grpc/pull/37#issuecomment-1449888452. In that PR I forgot to remove the already existing code for copying over files into META-INF so we ended up copying `LICENSE`/`NOTICE` and `DISCLAIMER` files twice.

@jrudolph Do you think there is merit in downgrading the sbt-assembly plugin incase the upgrade did any change that we are not aware of? I don't think this should be an issue, sbt people are usually very strict in not adding additional changes in future versions.