### PR TITLE
avoid publishing interopTests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,8 @@ lazy val sbtPlugin = Project(id = "sbt-plugin", base = file("sbt-plugin"))
       val p3 = (runtime / publishLocal).value
       // like publishLocal but disregarding `publish / skip`
       import sbt.internal.librarymanagement.IvyActions
-      val p4 = IvyActions.publish(ivyModule.value, (interopTests / publishLocalConfiguration).value, streams.value.log)
+      val p4 = IvyActions.publish((interopTests / ivyModule).value, (interopTests / publishLocalConfiguration).value,
+        streams.value.log)
     },
     scriptedBufferLog := false)
   .settings(


### PR DESCRIPTION
This is a workaround that could be avoided if sbt would support something akin to https://github.com/sbt/sbt/pull/7165.