### PR TITLE
Undo removal of pekko-http-cors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ lazy val mkBatAssemblyTask = taskKey[File]("Create a Windows bat assembly")
 (ThisBuild / dynverSeparator) := "-"
 
 ThisBuild / resolvers += "Apache Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
+ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshot") // Remove when proper release of pekko-http-cors is made
 
 val pekkoGrpcCodegenId = s"$pekkoPrefix-codegen"
 lazy val codegen = Project(id = "codegen", base = file("codegen"))

--- a/docs/src/main/paradox/server/grpc-web.md
+++ b/docs/src/main/paradox/server/grpc-web.md
@@ -34,12 +34,12 @@ native gRPC protocol on a different port than gRPC-Web, as the two protocols
 will likely require a different security story. You can use
 @apidoc[WebHandler.grpcWebHandler](WebHandler$) to serve your
 gRPC-Web endpoint with basic CORS infrastructure in place. To use CORS,
-you will need to add the akka-http-cors dependency to your project:
+you will need to add the pekko-http-cors dependency to your project:
 
 @@dependency[sbt,Maven,Gradle] {
   group="ch.megard"
-  artifact="akka-http-cors_2.12"
-  version="0.4.2"
+  artifact="pekko-http-cors_2.12"
+  version="0.0.0-SNAPSHOT" // Update when proper release of pekko-http-cors is made
 }
 
 And then serve the handlers with @apidoc[WebHandler.grpcWebHandler](WebHandler$) like this:

--- a/plugin-tester-java/build.gradle
+++ b/plugin-tester-java/build.gradle
@@ -13,6 +13,7 @@ pekkoGrpc {
 
 repositories {
   mavenLocal()
+  maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' } // Remove when proper release of pekko-http-cors is made
 }
 
 def scalaFullVersion = "2.12.16"
@@ -20,8 +21,7 @@ def scalaVersion = org.gradle.util.VersionNumber.parse(scalaFullVersion)
 def scalaBinaryVersion = "${scalaVersion.major}.${scalaVersion.minor}"
 
 dependencies {
-  // see https://github.com/apache/incubator-pekko-grpc/issues/22
-  // implementation group: 'ch.megard', name: "akka-http-cors_${scalaBinaryVersion}", version: '1.1.3'
+  implementation group: 'ch.megard', name: "pekko-http-cors_${scalaBinaryVersion}", version: '0.0.0-SNAPSHOT'
   implementation "org.scala-lang:scala-library:${scalaFullVersion}"
   testImplementation "org.apache.pekko:pekko-stream-testkit_${scalaBinaryVersion}:0.0.0+26599-83545a33-SNAPSHOT"
   testImplementation "org.scalatest:scalatest_${scalaBinaryVersion}:3.2.15"

--- a/plugin-tester-java/pom.xml
+++ b/plugin-tester-java/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
-    <akka.http.cors.version>1.1.0</akka.http.cors.version>
+    <pekko.http.cors.version>0.0.0-SNAPSHOT</pekko.http.cors.version>
     <grpc.version>1.48.1</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
     <project.encoding>UTF-8</project.encoding>
   </properties>
@@ -26,6 +26,12 @@
       <name>Apache Snapshots Repository</name>
       <url>https://repository.apache.org/content/repositories/snapshots/</url>
     </repository>
+    <!-- Remove when proper release of pekko-http-cors is made -->
+    <repository>
+      <id>sonatype-snapshots</id>
+      <name>Sonatype Snapshots Repository</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
   </repositories>
 
   <dependencies>
@@ -34,13 +40,11 @@
       <artifactId>pekko-grpc-runtime_2.12</artifactId>
       <version>${pekko.grpc.project.version}</version>
     </dependency>
-    <!--
     <dependency>
       <groupId>ch.megard</groupId>
-      <artifactId>akka-http-cors_2.12</artifactId>
-      <version>${akka.http.cors.version}</version>
+      <artifactId>pekko-http-cors_2.12</artifactId>
+      <version>${pekko.http.cors.version}</version>
     </dependency>
-    -->
 
     <!-- Needed for the generated client -->
     <dependency>

--- a/plugin-tester-scala/build.gradle
+++ b/plugin-tester-scala/build.gradle
@@ -8,6 +8,7 @@ pekkoGrpc {
 
 repositories {
   mavenLocal()
+  maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' } // Remove when proper release of pekko-http-cors is made
 }
 
 def scalaFullVersion = "2.12.16"
@@ -15,8 +16,7 @@ def scalaVersion = org.gradle.util.VersionNumber.parse(scalaFullVersion)
 def scalaBinaryVersion = "${scalaVersion.major}.${scalaVersion.minor}"
 
 dependencies {
-  // see https://github.com/apache/incubator-pekko-grpc/issues/22
-  // implementation group: 'ch.megard', name: "akka-http-cors_${scalaBinaryVersion}", version: '1.1.3'
+  implementation group: 'ch.megard', name: "pekko-http-cors_${scalaBinaryVersion}", version: '0.0.0-SNAPSHOT'
   implementation "org.scala-lang:scala-library:${scalaFullVersion}"
   testImplementation "org.apache.pekko:pekko-stream-testkit_${scalaBinaryVersion}:0.0.0+26599-83545a33-SNAPSHOT"
   testImplementation "org.scalatest:scalatest_${scalaBinaryVersion}:3.2.12"

--- a/plugin-tester-scala/pom.xml
+++ b/plugin-tester-scala/pom.xml
@@ -14,7 +14,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <pekko.version>0.0.0+26599-83545a33-SNAPSHOT</pekko.version>
-    <akka.http.cors.version>0.4.2</akka.http.cors.version>
+    <pekko.http.cors.version>0.0.0-SNAPSHOT</pekko.http.cors.version>
     <grpc.version>1.48.1</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
     <project.encoding>UTF-8</project.encoding>
   </properties>
@@ -25,6 +25,12 @@
       <name>Apache Snapshots Repository</name>
       <url>https://repository.apache.org/content/repositories/snapshots/</url>
     </repository>
+    <!-- Remove when proper release of pekko-http-cors is made -->
+    <repository>
+      <id>sonatype-snapshots</id>
+      <name>Sonatype Snapshots Repository</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
   </repositories>
 
   <dependencies>
@@ -33,13 +39,11 @@
       <artifactId>pekko-grpc-runtime_2.12</artifactId>
       <version>${pekko.grpc.project.version}</version>
     </dependency>
-    <!-- see https://github.com/apache/incubator-pekko-grpc/issues/22
     <dependency>
       <groupId>ch.megard</groupId>
-      <artifactId>akka-http-cors_2.12</artifactId>
-      <version>${akka.http.cors.version}</version>
+      <artifactId>pekko-http-cors_2.12</artifactId>
+      <version>${pekko.http.cors.version}</version>
     </dependency>
-    -->
 
     <dependency>
       <groupId>org.apache.pekko</groupId>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,6 +39,8 @@ object Dependencies {
     val pekkoDiscovery = "org.apache.pekko" %% "pekko-discovery" % Versions.pekko
     val pekkoSlf4j = "org.apache.pekko" %% "pekko-slf4j" % Versions.pekko
 
+    val pekkoHttpCors = "ch.megard" %% "pekko-http-cors" % "0.0.0-SNAPSHOT" // Apache v2
+
     val scalapbCompilerPlugin = "com.thesamet.scalapb" %% "compilerplugin" % scalapb.compiler.Version.scalapbVersion
     val scalapbRuntime = ("com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion)
       .exclude("io.grpc", "grpc-netty")
@@ -103,7 +105,7 @@ object Dependencies {
     Compile.pekkoHttpCore,
     Compile.pekkoHttp,
     Compile.pekkoDiscovery,
-    // Compile.akkaHttpCors % "provided",
+    Compile.pekkoHttpCors % "provided",
     Test.pekkoTestkit,
     Test.pekkoStreamTestkit,
     Test.scalaTest,
@@ -136,7 +138,7 @@ object Dependencies {
   val pluginTester = l ++= Seq(
     // usually automatically added by `suggestedDependencies`, which doesn't work with ReflectiveCodeGen
     Compile.grpcStub,
-    // Compile.akkaHttpCors,
+    Compile.pekkoHttpCors,
     Test.scalaTest,
     Test.scalaTestPlusJunit,
     Protobuf.googleCommonProtos)

--- a/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/WebHandler.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/scaladsl/WebHandler.scala
@@ -4,25 +4,25 @@
 
 package org.apache.pekko.grpc.scaladsl
 
-//import scala.collection.immutable
+import scala.collection.immutable
 import scala.concurrent.Future
 import org.apache.pekko
 import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.ApiMayChange
-//import pekko.http.javadsl.{ model => jmodel }
-import pekko.http.scaladsl.model.{ HttpRequest, HttpResponse }
-//import pekko.http.scaladsl.model.headers._
+import pekko.http.javadsl.{ model => jmodel }
+import pekko.http.scaladsl.model.{ HttpMethods, HttpRequest, HttpResponse }
+import pekko.http.scaladsl.model.headers._
 import pekko.http.scaladsl.server.Route
 import pekko.http.scaladsl.server.directives.MarshallingDirectives.handleWith
-//import ch.megard.akka.http.cors.scaladsl.CorsDirectives.cors
-//import ch.megard.akka.http.cors.scaladsl.model.HttpHeaderRange
-//import ch.megard.akka.http.cors.scaladsl.settings.CorsSettings
+import ch.megard.pekko.http.cors.scaladsl.CorsDirectives.cors
+import ch.megard.pekko.http.cors.scaladsl.model.HttpHeaderRange
+import ch.megard.pekko.http.cors.scaladsl.settings.CorsSettings
 
 @ApiMayChange
 object WebHandler {
 
   /** Default CORS settings to use for grpc-web */
-  /*val defaultCorsSettings: CorsSettings = CorsSettings.defaultSettings
+  val defaultCorsSettings: CorsSettings = CorsSettings.defaultSettings
     .withAllowCredentials(true)
     .withAllowedMethods(immutable.Seq(HttpMethods.POST, HttpMethods.OPTIONS))
     .withExposedHeaders(immutable.Seq(headers.`Status`.name, headers.`Status-Message`.name, `Content-Encoding`.name))
@@ -38,7 +38,7 @@ object WebHandler {
   private[grpc] def isCorsPreflightRequest(r: jmodel.HttpRequest): Boolean =
     r.method == HttpMethods.OPTIONS && r.getHeader(classOf[Origin]).isPresent && r
       .getHeader(classOf[`Access-Control-Request-Method`])
-      .isPresent*/
+      .isPresent
 
   /**
    * Creates a `HttpRequest` to `HttpResponse` handler for gRPC services that can be used in
@@ -49,13 +49,13 @@ object WebHandler {
    *  - Otherise if the request is not handled by one of the provided handlers, a _404: Not Found_ response is produced.
    */
   def grpcWebHandler(handlers: PartialFunction[HttpRequest, Future[HttpResponse]]*)(
-      implicit as: ClassicActorSystemProvider /*,
-      corsSettings: CorsSettings = defaultCorsSettings*/ ): HttpRequest => Future[HttpResponse] = {
+      implicit as: ClassicActorSystemProvider,
+      corsSettings: CorsSettings = defaultCorsSettings): HttpRequest => Future[HttpResponse] = {
     implicit val system = as.classicSystem
     val servicesHandler = ServiceHandler.concat(handlers: _*)
-    Route.toFunction /*cors(corsSettings)*/ {
+    Route.toFunction(cors(corsSettings) {
       handleWith(servicesHandler)
-    }
+    })
   }
 
 }


### PR DESCRIPTION
Now that a snapshot of pekko-http-cors has been released (see https://github.com/lomigmegard/akka-http-cors/issues/258#issuecomment-1454762806) this PR undoes the removal (see https://github.com/apache/incubator-pekko-grpc/pull/23/commits/c41a89c2435894d8cb85985b252bd239d7a666d9 and https://github.com/apache/incubator-pekko-grpc/pull/23)

Resolves: https://github.com/apache/incubator-pekko-grpc/issues/22