### PR TITLE
standardise on scalatest 3.2.15

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -13,14 +13,11 @@ updates.ignore = [
   { groupId = "com.typesafe.akka", artifactId = "akka-http" },
   { groupId = "com.typesafe.akka", artifactId = "akka-http-core" },
 
-  { groupId = "org.scalatest", artifactId = "scalatest" },
-
   # https://github.com/akka/akka-grpc/issues/1631
   { groupId = "com.google.protobuf", artifactId = "protobuf-java" }
 ]
 
 updates.pin = [
-  { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1." },
 
   # https://github.com/akka/akka-grpc/issues/1506
   { groupId = "org.eclipse.jgit", artifactId = "org.eclipse.jgit", version = "5." },

--- a/benchmark-java/build.sbt
+++ b/benchmark-java/build.sbt
@@ -25,8 +25,8 @@ val root = project
       "io.grpc" % "grpc-testing" % grpcVersion,
       "org.hdrhistogram" % "HdrHistogram" % "2.1.12",
       "org.apache.commons" % "commons-math3" % "3.6.1",
-      "org.scalatest" %% "scalatest" % "3.2.12" % "test",
-      "org.scalatestplus" %% "junit-4-12" % "3.2.2.0" % "test"),
+      "org.scalatest" %% "scalatest" % "3.2.15" % "test",
+      "org.scalatestplus" %% "junit-4-13" % "3.2.15.0" % "test"),
     PB.artifactResolver := PB.artifactResolver.dependsOn(codeGenProject / Compile / publishLocal).value)
 
 compile / javacOptions += "-Xlint:deprecation"

--- a/plugin-tester-java/build.gradle
+++ b/plugin-tester-java/build.gradle
@@ -25,5 +25,5 @@ dependencies {
   implementation "org.scala-lang:scala-library:${scalaFullVersion}"
   testImplementation "org.apache.pekko:pekko-stream-testkit_${scalaBinaryVersion}:0.0.0+26623-85c2a469-SNAPSHOT"
   testImplementation "org.scalatest:scalatest_${scalaBinaryVersion}:3.2.15"
-  testImplementation "org.scalatestplus:junit-4-12_${scalaBinaryVersion}:3.2.2.0"
+  testImplementation "org.scalatestplus:junit-4-13_${scalaBinaryVersion}:3.2.15.0"
 }

--- a/plugin-tester-scala/build.gradle
+++ b/plugin-tester-scala/build.gradle
@@ -19,7 +19,7 @@ dependencies {
   implementation group: 'ch.megard', name: "pekko-http-cors_${scalaBinaryVersion}", version: '0.0.0-SNAPSHOT'
   implementation "org.scala-lang:scala-library:${scalaFullVersion}"
   testImplementation "org.apache.pekko:pekko-stream-testkit_${scalaBinaryVersion}:0.0.0+26623-85c2a469-SNAPSHOT"
-  testImplementation "org.scalatest:scalatest_${scalaBinaryVersion}:3.2.12"
-  testImplementation "org.scalatestplus:junit-4-12_${scalaBinaryVersion}:3.2.2.0"
+  testImplementation "org.scalatest:scalatest_${scalaBinaryVersion}:3.2.15"
+  testImplementation "org.scalatestplus:junit-4-13_${scalaBinaryVersion}:3.2.15.0"
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
     // maven-plugin/src/main/maven/plugin.xml and org.apache.pekko.grpc.sbt.PekkoGrpcPlugin
     val googleProtobuf = "3.20.1" // checked synced by VersionSyncCheckPlugin
 
-    val scalaTest = "3.1.4"
+    val scalaTest = "3.2.15"
 
     val maven = "3.8.6"
   }
@@ -76,7 +76,7 @@ object Dependencies {
   object Test {
     final val Test = sbt.Test
     val scalaTest = "org.scalatest" %% "scalatest" % Versions.scalaTest % "test" // Apache V2
-    val scalaTestPlusJunit = "org.scalatestplus" %% "junit-4-12" % (Versions.scalaTest + ".0") % "test" // Apache V2
+    val scalaTestPlusJunit = "org.scalatestplus" %% "junit-4-13" % (Versions.scalaTest + ".0") % "test" // Apache V2
     val pekkoDiscoveryConfig = "org.apache.pekko" %% "pekko-discovery" % Versions.pekko % "test"
     val pekkoTestkit = "org.apache.pekko" %% "pekko-testkit" % Versions.pekko % "test"
     val pekkoStreamTestkit = "org.apache.pekko" %% "pekko-stream-testkit" % Versions.pekko % "test"

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
@@ -11,7 +11,7 @@ val grpcVersion = "1.48.1" // checked synced by VersionSyncCheckPlugin
 libraryDependencies ++= Seq(
   "io.grpc" % "grpc-interop-testing" % grpcVersion % "protobuf-src",
   "org.apache.pekko" %% "pekko-grpc-interop-tests" % sys.props("project.version") % "test",
-  "org.scalatest" %% "scalatest" % "3.0.4" % "test" // ApacheV2
+  "org.scalatest" %% "scalatest" % "3.2.15" % "test" // ApacheV2
 )
 
 scalacOptions ++= List("-unchecked", "-deprecation", "-language:_", "-encoding", "UTF-8")

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/org/apache/pekko/grpc/GrpcInteropSpec.scala
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/src/test/scala/org/apache/pekko/grpc/GrpcInteropSpec.scala
@@ -9,7 +9,6 @@ import pekko.http.scaladsl.server.{ Directive0, Directives, Route }
 
 import io.grpc.testing.integration.TestServiceHandlerFactory
 import io.grpc.testing.integration.test.TestService
-import org.scalatest.WordSpec
 
 import scala.collection.immutable
 

--- a/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/build.sbt
@@ -7,4 +7,4 @@ scalacOptions += "-Xfatal-warnings"
 enablePlugins(PekkoGrpcPlugin)
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % "test")
+  "org.scalatest" %% "scalatest" % "3.2.15" % "test")


### PR DESCRIPTION
* in pekko core, we have 'testkit' libs and those still support scalatest 3.1 for historic reasons (3.2 needed for scala 3 though).
* grpc doesn't have such a 'testkit', so seems tidier to use scalatest 3.2 - especially since pekko-http may soon support scala3 allowing pekko-grpc to potentially support scala3