### PR TITLE
Mark Maven plugin mojos as threadsafe.

### DIFF
--- a/maven-plugin/src/main/maven/plugin.xml
+++ b/maven-plugin/src/main/maven/plugin.xml
@@ -12,6 +12,7 @@
       <description>Generate Apache Pekko gRPC model and service code</description>
       <implementation>org.apache.pekko.grpc.maven.GenerateMojo</implementation>
       <instantiationStrategy>singleton</instantiationStrategy>
+      <threadSafe>true</threadSafe>
       <phase>generate-sources</phase>
 
       <parameters>
@@ -103,6 +104,7 @@
       <description>Generate test Apache Pekko gRPC model and service code</description>
       <implementation>org.apache.pekko.grpc.maven.TestGenerateMojo</implementation>
       <instantiationStrategy>singleton</instantiationStrategy>
+      <threadSafe>true</threadSafe>
       <phase>generate-test-sources</phase>
 
       <parameters>


### PR DESCRIPTION
The mojos in the pekkp-grpc Maven plugin are both singleton instantiated, but do not modify any Class or instance state, so should be safe to use on multiple worker threads.

This removes a warning when Maven is run with multiple worker threads (e.g. `mvn -T 4`):

> 
> [WARNING] *****************************************************************
> [WARNING] * Your build is requesting parallel execution, but project      *
> [WARNING] * contains the following plugin(s) that have goals not marked   *
> [WARNING] * as @threadSafe to support parallel building.                  *
> [WARNING] * While this /may/ work fine, please look for plugin updates    *
> [WARNING] * and/or request plugins be made thread-safe.                   *
> [WARNING] * If reporting an issue, report it against the plugin in        *
> [WARNING] * question, not against maven-core                              *
> [WARNING] *****************************************************************
> [WARNING] The following plugins are not marked @threadSafe in Indexing :: gRPC:
> [WARNING] com.lightbend.akka.grpc:akka-grpc-maven-plugin:2.1.6
> [WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
> [WARNING] *****************************************************************
> 