### PR TITLE
Update sbt-apache-sonatype and handle rename

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -15,14 +15,14 @@ import sbt.plugins.JvmPlugin
 import org.apache.pekko.grpc.Dependencies.Versions.{ scala212, scala213 }
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys.projectInfoVersion
 import com.typesafe.tools.mima.plugin.MimaKeys._
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
 import sbtdynver.DynVerPlugin
 import sbtdynver.DynVerPlugin.autoImport.dynverSonatypeSnapshots
 
 object Common extends AutoPlugin {
   override def trigger = allRequirements
 
-  override def requires = JvmPlugin && SonatypeApachePlugin && DynVerPlugin
+  override def requires = JvmPlugin && ApacheSonatypePlugin && DynVerPlugin
 
   private val consoleDisabledOptions = Seq("-Xfatal-warnings", "-Ywarn-unused", "-Ywarn-unused-import")
 

--- a/project/MetaInfLicenseNoticeCopy.scala
+++ b/project/MetaInfLicenseNoticeCopy.scala
@@ -9,8 +9,8 @@
 
 import sbt.Keys._
 import sbt._
-import org.mdedetrich.apache.sonatype.SonatypeApachePlugin
-import SonatypeApachePlugin.autoImport.apacheSonatypeDisclaimerFile
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
+import ApacheSonatypePlugin.autoImport.apacheSonatypeDisclaimerFile
 
 /**
  * Copies LICENSE and NOTICE files into jar META-INF dir
@@ -19,7 +19,7 @@ object MetaInfLicenseNoticeCopy extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  override def requires = SonatypeApachePlugin
+  override def requires = ApacheSonatypePlugin
 
   override lazy val projectSettings = Seq(
     apacheSonatypeDisclaimerFile := Some((LocalRootProject / baseDirectory).value / "DISCLAIMER"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.0")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.30")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.6")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.7")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
 
 // allow access to snapshots for pekko-sbt-paradox


### PR DESCRIPTION
Updates sbt-apache-sonatype. Note that this new version renames `SonatypeApachePlugin` to `ApacheSonatypePlugin` to be consistent with the project name.