### PR TITLE
Update sbt-apache-sonatype

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.0")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.30")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.7")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.9")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.5")
 
 // allow access to snapshots for pekko-sbt-paradox


### PR DESCRIPTION
Updates sbt-apache-sonatype which brings in https://github.com/mdedetrich/sbt-apache-sonatype/pull/16 and https://github.com/mdedetrich/sbt-apache-sonatype/pull/15