### PR TITLE
Unwrap single string interpolation syntax

### DIFF
--- a/benchmarks/src/main/scala/org/apache/pekko/grpc/BenchRunner.scala
+++ b/benchmarks/src/main/scala/org/apache/pekko/grpc/BenchRunner.scala
@@ -40,7 +40,7 @@ object BenchRunner {
         result.getParams.getParamsKeys.asScala.map(key => s"$key=${result.getParams.getParam(key)}").mkString("_")
       val score = result.getAggregatedResult.getPrimaryResult.getScore.round
       val unit = result.getAggregatedResult.getPrimaryResult.getScoreUnit
-      s"\t${bench}_${params}\t$score\t$unit"
+      s"\t${bench}_$params\t$score\t$unit"
     }
 
     report.toList.sorted.foreach(println)

--- a/maven-plugin/src/main/scala/org/apache/pekko/grpc/maven/AbstractGenerateMojo.scala
+++ b/maven-plugin/src/main/scala/org/apache/pekko/grpc/maven/AbstractGenerateMojo.scala
@@ -153,7 +153,7 @@ abstract class AbstractGenerateMojo @Inject() (buildContext: BuildContext) exten
       if (protoDir.exists()) {
         directoryFound = true
         // generated sources should be compiled
-        val generatedSourcesDir = s"${outputDirectory}/pekko-grpc${chosenLanguage.targetDirSuffix}"
+        val generatedSourcesDir = s"$outputDirectory/pekko-grpc${chosenLanguage.targetDirSuffix}"
         val compileSourceRoot = {
           val generatedSourcesFile = new File(generatedSourcesDir)
           if (!generatedSourcesFile.isAbsolute()) {

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -57,7 +57,7 @@ object CopyrightHeader extends AutoPlugin {
         case Some(currentText) if isOnlyLightbendCopyrightAnnotated(currentText) =>
           HeaderCommentStyle.twirlStyleBlockComment.commentCreator(text, existingText) + NewLine * 2 + currentText
         case Some(currentText) =>
-          throw new IllegalStateException(s"Unable to detect copyright for header: [${currentText}]")
+          throw new IllegalStateException(s"Unable to detect copyright for header: [$currentText]")
         case None =>
           HeaderCommentStyle.twirlStyleBlockComment.commentCreator(text, existingText)
       }
@@ -74,7 +74,7 @@ object CopyrightHeader extends AutoPlugin {
         case Some(currentText) if isOnlyLightbendCopyrightAnnotated(currentText) =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText) + NewLine * 2 + currentText
         case Some(currentText) =>
-          throw new IllegalStateException(s"Unable to detect copyright for header: [${currentText}]")
+          throw new IllegalStateException(s"Unable to detect copyright for header: [$currentText]")
         case None =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText)
       }
@@ -92,7 +92,7 @@ object CopyrightHeader extends AutoPlugin {
         case Some(currentText) if isOnlyLightbendCopyrightAnnotated(currentText) =>
           HeaderCommentStyle.hashLineComment.commentCreator(apacheSpdxHeader, existingText) + NewLine * 2 + currentText
         case Some(currentText) =>
-          throw new IllegalStateException(s"Unable to detect copyright for header: [${currentText}]")
+          throw new IllegalStateException(s"Unable to detect copyright for header: [$currentText]")
         case None =>
           HeaderCommentStyle.hashLineComment.commentCreator(apacheSpdxHeader, existingText)
       }


### PR DESCRIPTION
Unwraps single string interpolation i.e. `s"${something}"` into `s"$something"`. Make sure to do a rebase merge of this PR because I need to add its commit to `.git-blame-ignore-revs`