### PR TITLE
Add unwrap single string into .git-ignore-blame-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # scalafmt
 3b6138ee4093ae6c451d03e48d2bc085b3239731
+
+# manual
+6d565ee5f4851d9c7bb3546f684cceeb23b9eb73


### PR DESCRIPTION
Adds the changes from https://github.com/apache/incubator-pekko-grpc/pull/73 into `.git-ignore-blame-revs`.