### PR TITLE
Create NoPublish sbt plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import org.apache.pekko.grpc.Dependencies
 import org.apache.pekko.grpc.Dependencies.Versions.{ scala212, scala213 }
 import org.apache.pekko.grpc.ProjectExtensions._
+import org.apache.pekko.grpc.NoPublish
 import org.apache.pekko.grpc.build.ReflectiveCodeGen
 import com.typesafe.tools.mima.core._
 import sbt.Keys.scalaVersion
@@ -145,7 +146,6 @@ lazy val interopTests = Project(id = "interop-tests", base = file("interop-tests
     PB.protocVersion := Dependencies.Versions.googleProtobuf,
     // We need to be able to publish locally in order for sbt interopt tests to work
     // however this sbt project should not be published to an actual repository
-    publish / skip := true,
     publishLocal / skip := false,
     Compile / doc := (Compile / doc / target).value)
   .settings(inConfig(Test)(Seq(
@@ -165,7 +165,7 @@ lazy val interopTests = Project(id = "interop-tests", base = file("interop-tests
         }
         .dependsOn(Compile / products)
         .evaluated
-    })))
+    }))).enablePlugins(NoPublish)
 
 lazy val benchmarks = Project(id = "benchmarks", base = file("benchmarks"))
   .dependsOn(runtime)
@@ -174,8 +174,8 @@ lazy val benchmarks = Project(id = "benchmarks", base = file("benchmarks"))
   .settings(
     name := s"$pekkoPrefix-benchmarks",
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
-    scalaVersion := Dependencies.Versions.CrossScalaForLib.head,
-    (publish / skip) := true)
+    scalaVersion := Dependencies.Versions.CrossScalaForLib.head)
+  .enablePlugins(NoPublish)
 
 lazy val docs = Project(id = "docs", base = file("docs"))
 // Make sure code generation is run:
@@ -185,7 +185,6 @@ lazy val docs = Project(id = "docs", base = file("docs"))
   .disablePlugins(MimaPlugin)
   .settings(
     name := s"$pekkoPrefix-docs",
-    publish / skip := true,
     makeSite := makeSite.dependsOn(LocalRootProject / ScalaUnidoc / doc).value,
     pekkoParadoxGithub := Some("https://github.com/apache/incubator-pekko-grpc"),
     previewPath := (Paradox / siteSubdirName).value,
@@ -218,33 +217,32 @@ lazy val docs = Project(id = "docs", base = file("docs"))
   .settings(
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := Dependencies.Versions.CrossScalaForLib.head)
+  .enablePlugins(NoPublish)
 
 lazy val pluginTesterScala = Project(id = "plugin-tester-scala", base = file("plugin-tester-scala"))
   .disablePlugins(MimaPlugin)
   .settings(Dependencies.pluginTester)
   .settings(
     name := s"$pekkoPrefix-plugin-tester-scala",
-    (publish / skip) := true,
-    Compile / doc / sources := Seq(),
     fork := true,
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := scala212,
     ReflectiveCodeGen.codeGeneratorSettings ++= Seq("flat_package", "server_power_apis"))
   .pluginTestingSettings
+  .enablePlugins(NoPublish)
 
 lazy val pluginTesterJava = Project(id = "plugin-tester-java", base = file("plugin-tester-java"))
   .disablePlugins(MimaPlugin)
   .settings(Dependencies.pluginTester)
   .settings(
     name := s"$pekkoPrefix-plugin-tester-java",
-    (publish / skip) := true,
-    Compile / doc / sources := Seq(),
     fork := true,
     ReflectiveCodeGen.generatedLanguages := Seq("Java"),
     crossScalaVersions := Dependencies.Versions.CrossScalaForLib,
     scalaVersion := scala212,
     ReflectiveCodeGen.codeGeneratorSettings ++= Seq("server_power_apis"))
   .pluginTestingSettings
+  .enablePlugins(NoPublish)
 
 lazy val root = Project(id = "pekko-grpc", base = file("."))
   .enablePlugins(ScalaUnidocPlugin)
@@ -262,7 +260,6 @@ lazy val root = Project(id = "pekko-grpc", base = file("."))
     docs)
   .settings(
     name := s"$pekkoPrefix-root",
-    (publish / skip) := true,
     (Compile / headerCreate / unmanagedSources) := (baseDirectory.value / "project").**("*.scala").get,
     // unidoc combines sources and jars from all subprojects and that
     // might include some incompatible ones. Depending on the
@@ -277,3 +274,4 @@ lazy val root = Project(id = "pekko-grpc", base = file("."))
     // can then decide which scalaVersion and crossCalaVersions they use.
     crossScalaVersions := Nil,
     scalaVersion := scala212)
+  .enablePlugins(NoPublish)

--- a/project/NoPublish.scala
+++ b/project/NoPublish.scala
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package org.apache.pekko.grpc
+
+import sbt._
+import sbt.Keys._
+
+/**
+ * For projects that are not to be published.
+ */
+object NoPublish extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+
+  override def projectSettings =
+    Seq(publish / skip := true, Compile / doc / sources := Seq.empty)
+}


### PR DESCRIPTION
Regarding the PR that disabled javadoc publishing which was merged in order to get publishling to work (see https://github.com/apache/incubator-pekko-grpc/pull/78) I noticed that Pekko core implements a basic `NoPublish` sbt plugin which not only sets `publish / skip := true` but also disables publishing (see https://github.com/apache/incubator-pekko/blob/main/project/Publish.scala#L41C1-L49).

In order to avoid potential publishing issues (and also just out of design, if we do not publish an sbt project there is no point in generating docs) I have just ported this solution to pekko-grpc. There is one nuance just for pekk-grpc, which is `publishLocal / skip := false` for `interopt-tests` which was set in https://github.com/apache/incubator-pekko-grpc/pull/64. In order to verify there wasn't a regression I just used `show` on the various keys so I can confirm it shouldn't break anything, i.e.

## Before this PR
```
[IJ]show publish / skip
[info] maven-plugin / publish / skip
[info] 	false
[info] plugin-tester-java / publish / skip
[info] 	true
[info] benchmarks / publish / skip
[info] 	true
[info] sbt-plugin / publish / skip
[info] 	false
[info] interop-tests / publish / skip
[info] 	true
[info] runtime / publish / skip
[info] 	false
[info] codegen / publish / skip
[info] 	false
[info] plugin-tester-scala / publish / skip
[info] 	true
[info] docs / publish / skip
[info] 	true
[info] scalapb-protoc-plugin / publish / skip
[info] 	false
[info] publish / skip
[info] 	true
[success] Total time: 0 s, completed May 28, 2023 12:17:36 PM
[IJ]
```

```
[IJ]show publishLocal / skip
[info] maven-plugin / publishLocal / skip
[info] 	false
[info] plugin-tester-java / publishLocal / skip
[info] 	true
[info] benchmarks / publishLocal / skip
[info] 	true
[info] sbt-plugin / publishLocal / skip
[info] 	false
[info] interop-tests / publishLocal / skip
[info] 	false
[info] runtime / publishLocal / skip
[info] 	false
[info] codegen / publishLocal / skip
[info] 	false
[info] plugin-tester-scala / publishLocal / skip
[info] 	true
[info] docs / publishLocal / skip
[info] 	true
[info] scalapb-protoc-plugin / publishLocal / skip
[info] 	false
[info] publishLocal / skip
[info] 	true
[success] Total time: 0 s, completed May 28, 2023 12:17:51 PM
[IJ]
```

## With this PR
```
[IJ]show publish / skip
[info] maven-plugin / publish / skip
[info] 	false
[info] plugin-tester-java / publish / skip
[info] 	true
[info] benchmarks / publish / skip
[info] 	true
[info] sbt-plugin / publish / skip
[info] 	false
[info] interop-tests / publish / skip
[info] 	true
[info] runtime / publish / skip
[info] 	false
[info] codegen / publish / skip
[info] 	false
[info] plugin-tester-scala / publish / skip
[info] 	true
[info] docs / publish / skip
[info] 	true
[info] scalapb-protoc-plugin / publish / skip
[info] 	false
[info] publish / skip
[info] 	true
[success] Total time: 0 s, completed May 28, 2023 12:14:45 PM
```

```
[IJ]show publishLocal / skip
[info] maven-plugin / publishLocal / skip
[info] 	false
[info] plugin-tester-java / publishLocal / skip
[info] 	true
[info] benchmarks / publishLocal / skip
[info] 	true
[info] sbt-plugin / publishLocal / skip
[info] 	false
[info] interop-tests / publishLocal / skip
[info] 	false
[info] runtime / publishLocal / skip
[info] 	false
[info] codegen / publishLocal / skip
[info] 	false
[info] plugin-tester-scala / publishLocal / skip
[info] 	true
[info] docs / publishLocal / skip
[info] 	true
[info] scalapb-protoc-plugin / publishLocal / skip
[info] 	false
[info] publishLocal / skip
[info] 	true
[success] Total time: 0 s, completed May 28, 2023 12:15:12 PM
[IJ]
```