### PR TITLE
compile issue - now that we support Scala 3

### DIFF
--- a/plugin-tester-scala/src/test/scala/example/myapp/helloworld/ErrorReportingSpec.scala
+++ b/plugin-tester-scala/src/test/scala/example/myapp/helloworld/ErrorReportingSpec.scala
@@ -37,7 +37,7 @@ import scala.concurrent.duration._
 @RunWith(classOf[JUnitRunner])
 class ErrorReportingSpec extends AnyWordSpec with Matchers with ScalaFutures with BeforeAndAfterAll {
 
-  override implicit val patienceConfig = PatienceConfig(5.seconds, Span(100, org.scalatest.time.Millis))
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds, Span(100, org.scalatest.time.Millis))
 
   implicit val system: ActorSystem = ActorSystem()
 


### PR DESCRIPTION
This implicit without a type declaration is causing major CI build problems.

Oddly the fails here are in the 2.13 builds but they do relate to this untyped implicit. https://github.com/apache/incubator-pekko-grpc/pull/90/checks