### PR TITLE
revert to scala 2.13.10 due to compile problems

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ import buildinfo.BuildInfo
 object Dependencies {
   object Versions {
     val scala212 = "2.12.18"
-    val scala213 = "2.13.11"
+    val scala213 = "2.13.10"
     val scala3 = "3.3.0"
 
     // the order in the list is important because the head will be considered the default.


### PR DESCRIPTION
* the 2.13 compile still fails in CI (runtime / test) - example https://github.com/apache/incubator-pekko-grpc/actions/runs/5255290024/jobs/9495014216
* the actual compile issue is not in the logs
* it runs ok on my laptop
* it's more important to have CI working - we can spend time later trying to work out why Scala 2.13.11 compiler is struggling on CI machines

This is the commit that stopped Scala 2.13 CI builds working - https://github.com/apache/incubator-pekko-grpc/actions/runs/5191466278

