### PR TITLE
run right scala 3 tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SCALA_VERSION: [2.12, 2.13]
+        SCALA_VERSION: [2.12, 2.13, 3.3]
         JAVA_VERSION: [8, 11]
     steps:
       - name: Checkout
@@ -105,8 +105,6 @@ jobs:
             scala-version: 2.12
           - test-set: gen-java
             scala-version: 2.12
-          - test-set: scala3
-            scala-version: 3.3
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
* wrong matrix set
* the place where the 3.3 was added was for sbt plugin testing and sbt plugin only needs scala 2.12 testing
* we are missing scala 3.3 testing of runtime code