### PR TITLE
Update latest pekko-http to bring in cors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,10 +27,10 @@ lazy val mkBatAssemblyTask = taskKey[File]("Create a Windows bat assembly")
 // gradle plugin compatibility (avoid `+` in snapshot versions)
 (ThisBuild / dynverSeparator) := "-"
 
-// TODO: Remove when Pekko has a proper release
+// TODO remove these resolvers when we start using released Pekko jars
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
+ThisBuild / resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 ThisBuild / updateOptions := updateOptions.value.withLatestSnapshots(false)
-ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshot") // TODO Remove when proper release of pekko-http-cors is made
 
 val pekkoGrpcCodegenId = s"$pekkoPrefix-codegen"
 lazy val codegen = Project(id = "codegen", base = file("codegen"))

--- a/docs/src/main/paradox/server/grpc-web.md
+++ b/docs/src/main/paradox/server/grpc-web.md
@@ -37,9 +37,9 @@ gRPC-Web endpoint with basic CORS infrastructure in place. To use CORS,
 you will need to add the pekko-http-cors dependency to your project:
 
 @@dependency[sbt,Maven,Gradle] {
-  group="ch.megard"
-  artifact="pekko-http-cors_2.12"
-  version="0.0.0-SNAPSHOT" // Update when proper release of pekko-http-cors is made
+  group="org.apache.pekko"
+  artifact="pekko-http-cors_$scala.binary.version$"
+  version="$pekko-http.version$"
 }
 
 And then serve the handlers with @apidoc[WebHandler.grpcWebHandler](WebHandler$) like this:

--- a/plugin-tester-java/build.gradle
+++ b/plugin-tester-java/build.gradle
@@ -13,7 +13,7 @@ pekkoGrpc {
 
 repositories {
   mavenLocal()
-  maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' } // TODO Remove when proper release of pekko-http-cors is made
+  maven { url 'https://repository.apache.org/content/groups/staging/' } // TODO remove this resolver when we start using released Pekko jars
 }
 
 def scalaFullVersion = "2.12.18"
@@ -21,9 +21,9 @@ def scalaVersion = org.gradle.util.VersionNumber.parse(scalaFullVersion)
 def scalaBinaryVersion = "${scalaVersion.major}.${scalaVersion.minor}"
 
 dependencies {
-  implementation group: 'ch.megard', name: "pekko-http-cors_${scalaBinaryVersion}", version: '0.0.0-SNAPSHOT'
+  implementation group: 'org.apache.pekko', name: "pekko-http-cors_${scalaBinaryVersion}", version: '0.0.0+4456-9a4c0fc7-SNAPSHOT'
   implementation "org.scala-lang:scala-library:${scalaFullVersion}"
-  testImplementation "org.apache.pekko:pekko-stream-testkit_${scalaBinaryVersion}:0.0.0+26669-ec5b6764-SNAPSHOT"
+  testImplementation "org.apache.pekko:pekko-stream-testkit_${scalaBinaryVersion}:1.0.0-RC3"
   testImplementation "org.scalatest:scalatest_${scalaBinaryVersion}:3.2.15"
   testImplementation "org.scalatestplus:junit-4-13_${scalaBinaryVersion}:3.2.15.0"
 }

--- a/plugin-tester-java/pom.xml
+++ b/plugin-tester-java/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
     <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
-    <pekko.http.cors.version>0.0.0-SNAPSHOT</pekko.http.cors.version>
+    <pekko.http.version>0.0.0+4456-9a4c0fc7-SNAPSHOT</pekko.http.version>
     <grpc.version>1.48.1</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
     <project.encoding>UTF-8</project.encoding>
   </properties>
@@ -26,11 +26,11 @@
       <name>Apache Snapshots Repository</name>
       <url>https://repository.apache.org/content/repositories/snapshots/</url>
     </repository>
-    <!-- TODO Remove when proper release of pekko-http-cors is made -->
+    <!-- TODO remove this resolver when we start using released Pekko jars -->
     <repository>
-      <id>sonatype-snapshots</id>
-      <name>Sonatype Snapshots Repository</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <id>apache-staging</id>
+      <name>Apache Staging Repository</name>
+      <url>https://repository.apache.org/content/groups/staging/</url>
     </repository>
   </repositories>
 
@@ -41,9 +41,9 @@
       <version>${pekko.grpc.project.version}</version>
     </dependency>
     <dependency>
-      <groupId>ch.megard</groupId>
+      <groupId>org.apache.pekko</groupId>
       <artifactId>pekko-http-cors_2.12</artifactId>
-      <version>${pekko.http.cors.version}</version>
+      <version>${pekko.http.version}</version>
     </dependency>
 
     <!-- Needed for the generated client -->

--- a/plugin-tester-scala/build.gradle
+++ b/plugin-tester-scala/build.gradle
@@ -8,7 +8,7 @@ pekkoGrpc {
 
 repositories {
   mavenLocal()
-  maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' } // TODO Remove when proper release of pekko-http-cors is made
+  maven { url 'https://repository.apache.org/content/groups/staging/' } // TODO remove this resolver when we start using released Pekko jars
 }
 
 def scalaFullVersion = "2.12.18"
@@ -16,10 +16,9 @@ def scalaVersion = org.gradle.util.VersionNumber.parse(scalaFullVersion)
 def scalaBinaryVersion = "${scalaVersion.major}.${scalaVersion.minor}"
 
 dependencies {
-  implementation group: 'ch.megard', name: "pekko-http-cors_${scalaBinaryVersion}", version: '0.0.0-SNAPSHOT'
+  implementation group: 'org.apache.pekko', name: "pekko-http-cors_${scalaBinaryVersion}", version: '0.0.0+4456-9a4c0fc7-SNAPSHOT'
   implementation "org.scala-lang:scala-library:${scalaFullVersion}"
-  testImplementation "org.apache.pekko:pekko-stream-testkit_${scalaBinaryVersion}:0.0.0+26669-ec5b6764-SNAPSHOT"
+  testImplementation "org.apache.pekko:pekko-stream-testkit_${scalaBinaryVersion}:1.0.0-RC3"
   testImplementation "org.scalatest:scalatest_${scalaBinaryVersion}:3.2.15"
   testImplementation "org.scalatestplus:junit-4-13_${scalaBinaryVersion}:3.2.15.0"
 }
-

--- a/plugin-tester-scala/pom.xml
+++ b/plugin-tester-scala/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <pekko.version>0.0.0+26669-ec5b6764-SNAPSHOT</pekko.version>
-    <pekko.http.cors.version>0.0.0-SNAPSHOT</pekko.http.cors.version>
+    <pekko.version>1.0.0-RC3</pekko.version>
+    <pekko.http.version>0.0.0+4456-9a4c0fc7-SNAPSHOT</pekko.http.version>
     <grpc.version>1.48.1</grpc.version> <!-- checked synced by VersionSyncCheckPlugin -->
     <project.encoding>UTF-8</project.encoding>
   </properties>
@@ -25,11 +25,11 @@
       <name>Apache Snapshots Repository</name>
       <url>https://repository.apache.org/content/repositories/snapshots/</url>
     </repository>
-    <!-- TODO Remove when proper release of pekko-http-cors is made -->
+    <!-- TODO remove this resolver when we start using released Pekko jars -->
     <repository>
-      <id>sonatype-snapshots</id>
-      <name>Sonatype Snapshots Repository</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <id>apache-staging</id>
+      <name>Apache Staging Repository</name>
+      <url>https://repository.apache.org/content/groups/staging/</url>
     </repository>
   </repositories>
 
@@ -40,9 +40,9 @@
       <version>${pekko.grpc.project.version}</version>
     </dependency>
     <dependency>
-      <groupId>ch.megard</groupId>
+      <groupId>org.apache.pekko</groupId>
       <artifactId>pekko-http-cors_2.12</artifactId>
-      <version>${pekko.http.cors.version}</version>
+      <version>${pekko.http.version}</version>
     </dependency>
 
     <dependency>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,9 +26,9 @@ object Dependencies {
     // We don't force Pekko updates because downstream projects can upgrade
     // themselves. For more information see
     // https://pekko.apache.org//docs/pekko/current/project/downstream-upgrade-strategy.html
-    val pekko = "0.0.0+26669-ec5b6764-SNAPSHOT"
+    val pekko = "1.0.0-RC3"
     val pekkoBinary = "current"
-    val pekkoHttp = "0.0.0+4411-6fe04045-SNAPSHOT"
+    val pekkoHttp = "0.0.0+4456-9a4c0fc7-SNAPSHOT"
     val pekkoHttpBinary = "current"
 
     val grpc = "1.48.1" // checked synced by VersionSyncCheckPlugin
@@ -46,10 +46,9 @@ object Dependencies {
     val pekkoStream = "org.apache.pekko" %% "pekko-stream" % Versions.pekko
     val pekkoHttp = "org.apache.pekko" %% "pekko-http" % Versions.pekkoHttp
     val pekkoHttpCore = "org.apache.pekko" %% "pekko-http-core" % Versions.pekkoHttp
+    val pekkoHttpCors = "org.apache.pekko" %% "pekko-http-cors" % Versions.pekkoHttp
     val pekkoDiscovery = "org.apache.pekko" %% "pekko-discovery" % Versions.pekko
     val pekkoSlf4j = "org.apache.pekko" %% "pekko-slf4j" % Versions.pekko
-
-    val pekkoHttpCors = "ch.megard" %% "pekko-http-cors" % "0.0.0-SNAPSHOT" // Apache v2
 
     val scalapbCompilerPlugin = "com.thesamet.scalapb" %% "compilerplugin" % scalapb.compiler.Version.scalapbVersion
     val scalapbRuntime = ("com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion)
@@ -115,9 +114,7 @@ object Dependencies {
     Compile.pekkoHttpCore,
     Compile.pekkoHttp,
     Compile.pekkoDiscovery,
-    // TODO Remove exclusion rule when proper release of pekko-http-cors is made
-    (Compile.pekkoHttpCors % "provided").excludeAll(
-      "org.apache.pekko" %% "pekko-http"),
+    Compile.pekkoHttpCors,
     Compile.pekkoHttp % "provided",
     Test.pekkoTestkit,
     Test.pekkoStreamTestkit,
@@ -151,9 +148,7 @@ object Dependencies {
   val pluginTester = l ++= Seq(
     // usually automatically added by `suggestedDependencies`, which doesn't work with ReflectiveCodeGen
     Compile.grpcStub,
-    // TODO Remove exclusion rule when proper release of pekko-http-cors is made
-    Compile.pekkoHttpCors.excludeAll(
-      "org.apache.pekko" %% "pekko-http"),
+    Compile.pekkoHttpCors,
     Compile.pekkoHttp,
     Test.scalaTest,
     Test.scalaTestPlusJunit,

--- a/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/WebHandler.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/javadsl/WebHandler.scala
@@ -21,6 +21,8 @@ import pekko.NotUsed
 import pekko.actor.ClassicActorSystemProvider
 import pekko.annotation.ApiMayChange
 import pekko.grpc.javadsl.ServiceHandler.{ concatOrNotFound, unsupportedMediaType }
+import pekko.http.cors.javadsl.settings.CorsSettings
+import pekko.http.cors.javadsl.CorsDirectives
 import pekko.http.javadsl.marshalling.Marshaller
 import pekko.http.javadsl.model.{ HttpRequest, HttpResponse }
 import pekko.http.javadsl.server.Route
@@ -32,8 +34,6 @@ import pekko.japi.function.{ Function => JFunction }
 import pekko.stream.Materializer
 import pekko.stream.javadsl.{ Keep, Sink, Source }
 import pekko.util.ConstantFun
-import ch.megard.pekko.http.cors.javadsl.settings.CorsSettings
-import ch.megard.pekko.http.cors.javadsl.CorsDirectives
 
 @ApiMayChange
 object WebHandler {

--- a/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/build.sbt
@@ -2,7 +2,9 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 enablePlugins(PekkoGrpcPlugin)
 

--- a/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/build.sbt
@@ -2,7 +2,9 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 enablePlugins(PekkoGrpcPlugin)
 

--- a/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/build.sbt
@@ -2,7 +2,9 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 enablePlugins(PekkoGrpcPlugin)
 

--- a/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/build.sbt
@@ -2,7 +2,9 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 enablePlugins(PekkoGrpcPlugin)
 

--- a/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/build.sbt
@@ -2,7 +2,9 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 enablePlugins(PekkoGrpcPlugin)
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/build.sbt
@@ -2,7 +2,9 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 organization := "org.apache.pekko"
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/build.sbt
@@ -2,7 +2,9 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 scalacOptions += "-Xfatal-warnings"
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/02-multiple-services/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/02-multiple-services/build.sbt
@@ -2,6 +2,8 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 enablePlugins(PekkoGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/build.sbt
@@ -2,7 +2,9 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 enablePlugins(PekkoGrpcPlugin)
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/build.sbt
@@ -2,6 +2,8 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 enablePlugins(PekkoGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/build.sbt
@@ -2,6 +2,8 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 enablePlugins(PekkoGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/build.sbt
@@ -2,7 +2,9 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 enablePlugins(ProtocJSPlugin) // enable it first to test possibility of getting overriden
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-pekko/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-pekko/build.sbt
@@ -2,7 +2,9 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 enablePlugins(PekkoGrpcPlugin)
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/build.sbt
@@ -2,7 +2,9 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 enablePlugins(PekkoGrpcPlugin)
 

--- a/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/build.sbt
@@ -2,7 +2,9 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 //#setup
 import scalapb.GeneratorOption._

--- a/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/build.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/build.sbt
@@ -2,6 +2,8 @@
 // https://github.com/akka/akka-grpc/pull/1279
 scalaVersion := "2.12.18"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 enablePlugins(PekkoGrpcPlugin)

--- a/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/build.sbt
@@ -1,6 +1,8 @@
 scalaVersion := "3.3.0"
 
+// TODO remove these resolvers when we start using released Pekko jars
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+resolvers += "apache-staging".at("https://repository.apache.org/content/groups/staging/")
 
 scalacOptions += "-Xfatal-warnings"
 


### PR DESCRIPTION
Also removes the now unnecessary Snapshot OSS repo, removes other workarounds and updates pekko core to 1.0.0-RC3.