### PR TITLE
Remove redundant oss sonatype snapshots repo

### DIFF
--- a/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPlugin.groovy
@@ -52,12 +52,8 @@ class PekkoGrpcPlugin implements Plugin<Project> {
         def baselineVersion = getBaselineVersion(pekkoGrpcExt.pluginVersion)
 
         project.repositories {
-            mavenLocal()
             mavenCentral()
             if (VersionNumber.parse(baselineVersion).qualifier) {
-                maven {
-                    url "https://oss.sonatype.org/content/repositories/snapshots"
-                }
                 maven {
                     url "https://repository.apache.org/content/groups/snapshots"
                 }


### PR DESCRIPTION
The original reason behind this repository being there is its used to resolve akka-grpc snapshot versions which were deployed to OSS sonatype. In https://github.com/apache/incubator-pekko-grpc/pull/23 we added more repos so that pekko-grpc could build with both akka (before akka/akka-http was even published as a snapshot) but since all dependencies are now properly released and we are not relying on akka artifacts anymore ideally we should only have a single `https://repository.apache.org/content/groups/snapshots` (which is our equivalent of `https://oss.sonatype.org/content/repositories/snapshots`), just like it was before we started working on the original akka-grpc branch.