### PR TITLE
Fix grpc gradle sonatype publish uri

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -54,7 +54,7 @@ publishing {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://repository.apache.org/"))
+            nexusUrl.set(uri("https://repository.apache.org/service/local/"))
             snapshotRepositoryUrl.set(uri("https://repository.apache.org/content/repositories/snapshots/"))
             username = System.getenv("NEXUS_USER")
             password = System.getenv("NEXUS_PW")


### PR DESCRIPTION
The previously entered URI is wrong, instead should have `/service/local` at the end (i.e. Apache equivalent of https://github.com/gradle-nexus/publish-plugin/blob/b116c25e9271734341be8078ab264b70e87f51cc/src/main/kotlin/io/github/gradlenexus/publishplugin/DefaultNexusRepositoryContainer.kt#L37)

References: https://github.com/apache/incubator-pekko-grpc/issues/113