### PR TITLE
Derive gradle version from sbt

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,14 +31,6 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
 
-      #- name: FOSSA policy check
-      #  if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'apache/incubator-pekko-grpc' }}
-      #  run: |-
-      #    curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
-      #    fossa analyze && fossa test
-      #  env:
-      #    FOSSA_API_KEY: "${{secrets.FOSSA_API_KEY}}"
-
       - name: Binary-compatibility check
         run: |-
           cp .jvmopts-ci .jvmopts
@@ -143,7 +135,7 @@ jobs:
 
       - name: Gather version
         run: |-
-          echo `git describe --tags | sed -e "s/v\(.*\)-\([0-9][0-9]*\).*/\\1-\\2-/"``git rev-parse HEAD | head -c8`-SNAPSHOT > ~/.version
+          echo `sbt --no-colors --error 'set aggregate := false; print version' | xargs` > ~/.version
           cat ~/.version
 
       - name: Cache local Gradle repository
@@ -167,12 +159,12 @@ jobs:
       - name: Test Gradle Java ${{ matrix.SCALA_VERSION }}
         run: |-
           cd plugin-tester-java
-          ./gradlew clean test --console=plain --info --stacktrace -Dpekko.grpc.project.version=$(cat ~/.version | sed -e s/-SNAPSHOT//)
+          ./gradlew clean test --console=plain --info --stacktrace -Dpekko.grpc.project.version=$(cat ~/.version)
 
       - name: Test Gradle Scala ${{ matrix.SCALA_VERSION }}
         run: |-
           cd plugin-tester-scala
-          ./gradlew clean test --console=plain --info --stacktrace -Dpekko.grpc.project.version=$(cat ~/.version | sed -e s/-SNAPSHOT//)
+          ./gradlew clean test --console=plain --info --stacktrace -Dpekko.grpc.project.version=$(cat ~/.version)
 
       - name: Stop Gradle Daemon
         # as suggested in https://github.com/actions/cache/blob/main/examples.md#java---gradle
@@ -199,7 +191,7 @@ jobs:
 
       - name: Gather version
         run: |-
-          echo `git describe --tags | sed -e "s/v\(.*\)-\([0-9][0-9]*\).*/\\1-\\2-/"``git rev-parse HEAD | head -c8`-SNAPSHOT > ~/.version
+          echo `sbt --no-colors --error 'set aggregate := false; print version' | xargs` > ~/.version
           cat ~/.version
 
       - name: Cache local Maven repository

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -32,7 +32,7 @@ jobs:
           NEXUS_PW: ${{ secrets.NEXUS_PW }}
 
       - name: Publish Gradle Plugin to Apache Nexus Repository
-        run: cd gradle-plugin && ./gradlew properties -q | awk '/^version:/ {print $2}' && ./gradlew publishToSonatype
+        run: cd gradle-plugin && ./gradlew publishToSonatype
         env:
           NEXUS_USER: ${{ secrets.NEXUS_USER }}
           NEXUS_PW: ${{ secrets.NEXUS_PW }}

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -2,17 +2,25 @@ plugins {
   id 'groovy'
   id 'java-gradle-plugin'
   id 'maven-publish'
-  id 'com.palantir.git-version' version '0.10.1'
   id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
 }
 
 group = "org.apache.pekko"
-// https://github.com/palantir/gradle-git-version/issues/97
 
-def tag = "git describe --tags".execute().text.substring(1).split("-g")[0].replace("\n", "")
-def finalVersion = (tag == versionDetails().lastTag.substring(1)) ? tag : tag.reverse().reverse() + "-" + versionDetails().gitHash.substring(0, 8)
-
-version = finalVersion
+def getVersionFromParentSbtBuild() {
+    ByteArrayOutputStream os = new ByteArrayOutputStream()
+    String parentDir = project.rootDir.getParentFile().getPath()
+    exec {
+        workingDir parentDir
+        commandLine 'sbt', '--no-colors', '--error', 'set aggregate := false; print version'
+        standardOutput os
+    }
+    os.close()
+    String finalVersion = os.toString().trim()
+    project.logger.info("Derived gradle version from parent sbt build: $finalVersion")
+    return finalVersion
+}
+version = getVersionFromParentSbtBuild()
 
 gradlePlugin {
   plugins {

--- a/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPlugin.groovy
+++ b/gradle-plugin/src/main/groovy/org/apache/pekko/grpc/gradle/PekkoGrpcPlugin.groovy
@@ -21,14 +21,8 @@ class PekkoGrpcPlugin implements Plugin<Project> {
 
     Project project
 
-    // workaround for test projects, when one only needs to tests a new plugin version without rebuilding dependencies.
-    String getBaselineVersion(String pluginVersion) {
-        def pv = System.getProperty("pekko.grpc.baseline.version", pluginVersion)
-        if (VersionNumber.parse(pv).qualifier) {
-            pv + "-SNAPSHOT"
-        } else {
-            pv
-        }
+    static String getBaselineVersion(String pluginVersion) {
+        System.getProperty("pekko.grpc.baseline.version", pluginVersion)
     }
 
     @Override

--- a/plugin-tester-java/settings.gradle
+++ b/plugin-tester-java/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
   repositories {
     mavenLocal()
-    gradlePluginPortal()
+    mavenCentral()
   }
   plugins {
     id 'org.apache.pekko.grpc.gradle' version "${System.getProperty('pekko.grpc.project.version')}"


### PR DESCRIPTION
So I can confirm that the reason behind the gradle plugin not building correctly is that it wasn't setting the version correctly (see https://github.com/apache/incubator-pekko-grpc/actions/runs/5786987516/job/15682898907). After spending the last few hours digging around to figure out how gradle publishing works I came up with an elegant solution that also simplifies whats going on.

Currently the gradle version is manually derived from executing git and parsing the results. Not only is this quite brittle (the sed regex would fail once we start releasing RC's/milestones for this same reason https://github.com/apache/incubator-pekko-http/issues/293#issuecomment-1666861760) but it also requires quite a bit of boilerplate because every single time we need to publish the gradle plugin (whether it is locally, as a snapshot or in production) we have to repeat the boilerplate of deriving the version from git tag and placing it in `~/.version` or when doing a full release setting the version in `build.gradle`.

So the best way to solve is this issue is why don't we just get the version directly from sbt? sbt is the source of truth when it comes to versions, its already doing the job deriving the version from a git tag via sbt-dynver and if the gradle plugin was hypothetically written as an sbt build it would be using the same version anyways.

If you want to verify this PR locally, you can just run `./gradlew properties -q | awk '/^version:/ {print $2}'`, `./gradlew properties` is the source of truth for what is the final calculated version.

tl;dr This change means that loading gradle will "just work" and removes all of the hacky git/regex parsing that currently exists, making the whole build a lot simpler. As a bonus it also means that the project works locally (historically I had to manually hardcode the version in build.gradle because as soon as the git pattern failed the regex the gradle build would fail to load).

References: https://github.com/apache/incubator-pekko-grpc/issues/113