### PR TITLE
Update references of gradlePluginPortal to mavenCentral

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -31,7 +31,7 @@ jobs:
           NEXUS_USER: ${{ secrets.NEXUS_USER }}
           NEXUS_PW: ${{ secrets.NEXUS_PW }}
 
-      - name: Publish Gradle Plugin to Apache Nexus Repository
+      - name: Publish Gradle Plugin
         run: cd gradle-plugin && ./gradlew publishToSonatype
         env:
           NEXUS_USER: ${{ secrets.NEXUS_USER }}

--- a/README.md
+++ b/README.md
@@ -98,7 +98,13 @@ See the note in the [Akka HTTP docs](https://doc.akka.io/docs/akka-http/10.1/ser
     - `mvn -Dpekko.grpc.project.version=<version> pekko-grpc:generate scala:compile`
 
 #### Gradle plugin
-- see [Installation docs](https://pekko.apache.org/docs/pekko-grpc/current/buildtools/gradle.html#installation)
+- the Gradle plugin is built using gradle
+- The gradle plugin will automatically derive the version of the artifact from sbt.
+  - In other words sbt is the source of truth when it comes to deriving the version
+- You can test the Gradle plugin by change directory into the `plugin-tester-java` dir
+  - `./gradlew clean test -Dpekko.grpc.project.version=<version>`
+- You can run the equivalent Scala tests by changing directory into the `plugin-tester-scala` dir
+  - `./gradlew clean test -Dpekko.grpc.project.version=<version>`
 
 ## License
 

--- a/docs/src/main/paradox/buildtools/gradle.md
+++ b/docs/src/main/paradox/buildtools/gradle.md
@@ -13,25 +13,14 @@ By default, both client and server are generated and Java or Scala is autodetect
 
 ### Installation
 
-**The Gradle plugin is not yet deployed to plugins.gradle.org.**
-
-For now, you will you need to build the plugin yourself and deploy to your local Maven repository.
-Unfortunately, the [Gradle Plugin Publishing](https://docs.gradle.org/current/userguide/publishing_gradle_plugins.html) plugin
-does not appear to support publishing to repositories that require authentication (e.g. Artifactory).
-
-If you check out the source code from our [git repo](https://github.com/apache/incubator-pekko-grpc)
-or [download](https://pekko.apache.org/download.html) a source release, you can change directory to the
-`gradle-plugin` directory and run this Gradle command.
-
-```shell
-./gradlew clean publishToMavenLocal
-```
-
-To consume this plugin, you will need to update the consuming project's `build.gradle` to include the `mavenLocal` repository.
+To consume this plugin, you will need to update the consuming project's `build.gradle` to include the `mavenCentral` repository.
 
 ```groovy
-repositories {
-  mavenLocal()
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
 }
 ```
 

--- a/docs/src/main/paradox/release-notes/index.md
+++ b/docs/src/main/paradox/release-notes/index.md
@@ -24,6 +24,12 @@ We haven't had to fix any significant bugs that were in Akka gRPC 2.1.6.
     * `googleProtocVersion` is the version of [Protoc](https://grpc.io/docs/protoc-installation/) that is supported (3.20.1)
     * `googleProtobufJavaVersion` is the version of [Protobuf Java](https://protobuf.dev/getting-started/javatutorial/) that is supported (3.20.3)
     * Akka gRPC 2.1.6 equivalent has just one property, `googleProtobufVersion`.
+* The Pekko gRPC plugin is deployed in Maven Central unlike the Akka gRPC plugin which was deployed
+  in [Gradle Plugin Portal](https://plugins.gradle.org/). This means that in addition to changing
+  the artifact from `akka-grpc-gradle-plugin` to `pekko-grpc-gradle-plugin` you also need to add
+  `mavenCentral()` to the `pluginManagement`'s `repositories` entry. See
+  [Installation docs](https://pekko.apache.org/docs/pekko-grpc/current/buildtools/gradle.html#installation) for more
+  info.
 
 ### Additions
 

--- a/docs/src/main/paradox/server/walkthrough.md
+++ b/docs/src/main/paradox/server/walkthrough.md
@@ -26,6 +26,7 @@ Gradle
       repositories {
         mavenLocal()
         gradlePluginPortal()
+        mavenCentral()
       }
       dependencies {
         // see https://plugins.gradle.org/plugin/org.apache.pekko.grpc.gradle
@@ -256,5 +257,3 @@ Java
 :  @@snip [GreeterActor.java](/plugin-tester-java/src/main/java/example/myapp/statefulhelloworld/GreeterActor.java) { #actor }
 
 Now the actor mailbox is used to synchronize accesses to the mutable state.
-
-

--- a/plugin-tester-scala/settings.gradle
+++ b/plugin-tester-scala/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
   repositories {
     mavenLocal()
-    gradlePluginPortal()
+    mavenCentral()
   }
   plugins {
     id 'org.apache.pekko.grpc.gradle' version "${System.getProperty('pekko.grpc.project.version')}"


### PR DESCRIPTION
The Gradle plugin now successfully deploys to maven central, see https://github.com/apache/incubator-pekko-grpc/actions/runs/5789438448/job/15690488703. The PR updates the documentation and also updates all references from `gradlePluginPortal`.

Resolves: https://github.com/apache/incubator-pekko-grpc/issues/113.