### PR TITLE
Add signing for release artifacts

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -2,6 +2,7 @@ plugins {
   id 'groovy'
   id 'java-gradle-plugin'
   id 'maven-publish'
+  id 'signing'
   id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
 }
 
@@ -79,6 +80,16 @@ nexusPublishing {
             password = getEnvVariable("NEXUS_PW")
         }
     }
+}
+
+Boolean isReleaseVersion = !version.toString().endsWith("SNAPSHOT")
+
+signing {
+    setRequired({
+        isReleaseVersion && gradle.taskGraph.hasTask("publish")
+    })
+    useGpgCmd()
+    sign configurations.archives
 }
 
 jar {


### PR DESCRIPTION
I havent tried this out yet, mainly just used the instructions from https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signing_publications but I suspect we will find out if the signing works when we get there.