### PR TITLE
add LEGAL-626 header to pom.xml files

### DIFF
--- a/plugin-tester-java/pom.xml
+++ b/plugin-tester-java/pom.xml
@@ -1,3 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ license agreements; and to You under the Apache License, version 2.0:
+
+   https://www.apache.org/licenses/LICENSE-2.0
+
+ This file is part of the Apache Pekko project, which was derived from Akka.
+-->
 <!--
   To test locally, first 'sbt maven-plugin:publishM2' in the parent dir
   and define the published version as pekko.grpc.project.version in the properties block below

--- a/plugin-tester-scala/pom.xml
+++ b/plugin-tester-scala/pom.xml
@@ -1,3 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ license agreements; and to You under the Apache License, version 2.0:
+
+   https://www.apache.org/licenses/LICENSE-2.0
+
+ This file is part of the Apache Pekko project, which was derived from Akka.
+-->
 <!--
   To test locally, first 'sbt maven-plugin:publishM2' in the parent dir
   and define the published version as pekko.grpc.project.version in the properties block below


### PR DESCRIPTION
The header should go after the XML declaration - eg https://github.com/apache/hadoop/blob/trunk/pom.xml