### PR TITLE
get jar signing to work

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -12,7 +12,7 @@ plugins {
   id 'java-gradle-plugin'
   id 'maven-publish'
   id 'signing'
-  id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
+  id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
 }
 
 group = "org.apache.pekko"
@@ -94,11 +94,12 @@ nexusPublishing {
 Boolean isReleaseVersion = !version.toString().endsWith("SNAPSHOT")
 
 signing {
-    setRequired({
-        isReleaseVersion && gradle.taskGraph.hasTask("publish")
-    })
-    useGpgCmd()
-    sign configurations.archives
+    required { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
+    sign publishing.publications
+}
+
+tasks.withType(Sign) {
+    onlyIf { isReleaseVersion }
 }
 
 jar {


### PR DESCRIPTION
Release mangers will need to set up their `~/.gradle/gradle.properties` when creating a release candidate.

* https://docs.gradle.org/6.9.1/userguide/signing_plugin.html#sec:conditional_signing

They will need to add these props but correct the values to match their gpg setup.
```
signing.keyId=24875D73
signing.password=secret
signing.secretKeyRingFile=/Users/me/.gnupg/secring.gpg
```