### PR TITLE
Rename sbt plugin artifact so it's consistent with other artifacts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,7 +133,7 @@ lazy val sbtPlugin = Project(id = "sbt-plugin", base = file("sbt-plugin"))
   .disablePlugins(MimaPlugin)
   .settings(Dependencies.sbtPlugin)
   .settings(
-    name := s"sbt-$pekkoPrefix",
+    name := s"$pekkoPrefix-sbt-plugin",
     /** And for scripted tests: */
     scriptedLaunchOpts += ("-Dproject.version=" + version.value),
     scriptedLaunchOpts ++= sys.props.collect { case (k @ "sbt.ivy.home", v) => s"-D$k=$v" }.toSeq,

--- a/docs/src/main/paradox/release-notes/index.md
+++ b/docs/src/main/paradox/release-notes/index.md
@@ -30,6 +30,9 @@ We haven't had to fix any significant bugs that were in Akka gRPC 2.1.6.
   `mavenCentral()` to the `pluginManagement`'s `repositories` entry. See
   [Installation docs](https://pekko.apache.org/docs/pekko-grpc/current/buildtools/gradle.html#installation) for more
   info.
+* The naming convention of the Pekko gRPC sbt plugin has changed, i.e. whereas
+  with Akka the artifact was named `sbt-akka-grpc` with Pekko it's named
+  `pekko-grpc-sbt-plugin` so it's consistent with `pekko-grpc-gradle-plugin`/`pekko-grpc-maven-plugin`.
 
 ### Additions
 

--- a/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/project/plugins.sbt
@@ -7,6 +7,6 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")

--- a/sbt-plugin/src/sbt-test/gen-scala-server/02-multiple-services/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/02-multiple-services/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-pekko/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-pekko/project/plugins.sbt
@@ -7,6 +7,6 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")

--- a/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/project/plugins.sbt
@@ -7,6 +7,6 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))
 
 libraryDependencies ++= Seq("com.thesamet.scalapb" %% "scalapb-validate-codegen" % "0.3.0")

--- a/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))

--- a/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/project/plugins.sbt
@@ -7,4 +7,4 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % sys.props("project.version"))
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % sys.props("project.version"))


### PR DESCRIPTION
Currently the artifact name for the sbt plugin is inconsistent with the other artifacts that pekko-grpc generates, i.e. currently the sbt artifact name is `sbt-pekko-grpc` where as all other artifacts start with `pekko-grpc-<REST>`. This even includes the other build tool plugins that pekko-grpc provides, i.e. `pekko-grpc-gradle-plugin`/`pekko-grpc-maven-plugin`