### PR TITLE
add license details for proto file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -264,7 +264,7 @@ Copyright 2014 The gRPC Authors
 
 ---------------
 
-Pekko gRPC contains a sample proto file from cloudstateio/dotnet-suppor
+Pekko gRPC contains a sample proto file from cloudstateio/dotnet-support
 <https://github.com/cloudstateio/dotnet-support> distributed under the Apache 2.0 license.
 
  - interop-tests/src/main/protobuf/crdt-example.proto

--- a/LICENSE
+++ b/LICENSE
@@ -261,3 +261,10 @@ distributed under the Apache 2.0 license.
 - benchmark-java/src/main/protobuf/stats.proto
 
 Copyright 2014 The gRPC Authors
+
+---------------
+
+Pekko gRPC contains a sample proto file from cloudstateio/dotnet-suppor
+<https://github.com/cloudstateio/dotnet-support> distributed under the Apache 2.0 license.
+
+ - interop-tests/src/main/protobuf/crdt-example.proto


### PR DESCRIPTION
I'm not 100% sure but the file we inherited from akka-grpc looks very similar to a file I found on the web and it was checked in in February 2020 - a month before the Akka file.

https://github.com/cloudstateio/dotnet-support/blob/master/examples/Crdt.Example/proto_files/example/crdts/crdt-example.proto

https://github.com/akka/akka-grpc/commits/main/interop-tests/src/main/protobuf/crdt-example.proto

There is no source header on either file and the LICENSE file in the https://github.com/cloudstateio/dotnet-support/ project is a standard Apache v2.0 license with no specific copyright in it.

https://github.com/cloudstateio/dotnet-support/