### PR TITLE
upgrade protobuf-java to 3.21.12

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
     // If changing this, remember to update protoc plugin version to align in
     // maven-plugin/src/main/maven/plugin.xml and org.apache.pekko.grpc.sbt.PekkoGrpcPlugin
     val googleProtoc = "3.20.1" // checked synced by VersionSyncCheckPlugin
-    val googleProtobufJava = "3.20.3"
+    val googleProtobufJava = "3.21.12"
 
     val scalaTest = "3.2.15"
 


### PR DESCRIPTION
grpc lib uses a newer version of protobuf-java (3.21.1) then we set (3.20.3) but this has CVEs