### PR TITLE
Update to SBT 1.9.6 and remove build.properties boilerplate

### DIFF
--- a/benchmark-java/project/build.properties
+++ b/benchmark-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.5
+sbt.version=1.9.6

--- a/build.sbt
+++ b/build.sbt
@@ -142,6 +142,7 @@ lazy val sbtPlugin = Project(id = "sbt-plugin", base = file("sbt-plugin"))
       val p3 = (runtime / publishLocal).value
       val p4 = (interopTests / publishLocal).value
     },
+    scriptedSbt := "1.9.6",
     scriptedBufferLog := false)
   .settings(
     crossScalaVersions := Dependencies.Versions.CrossScalaForPlugin,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.5
+sbt.version=1.9.6

--- a/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-java/01-gen-basic-java/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-java/02-server-reflection/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-java/03-no-java-package/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-java/04-crash-on-keywords/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-java/05-duplicate-messages-different-packages/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/00-interop/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/01-gen-basic-server/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-scala-server/02-multiple-services/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/02-multiple-services/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/03-test-config/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/04-server-reflection/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/05-no-java-package/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/06-compatibility-plugins/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-pekko/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/07-gen-basic-server-with-pekko/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/09-scalapb-customizations/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/10-scalapb-validate/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/project/build.properties
+++ b/sbt-plugin/src/sbt-test/gen-scala-server/11-duplicate-messages-different-packages/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5

--- a/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/project/build.properties
+++ b/sbt-plugin/src/sbt-test/scala3/01-basic-client-server/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.9.5


### PR DESCRIPTION
Trick I got from https://github.com/sbt/sbt-github-actions/pull/163#discussion_r1327598500