### PR TITLE
Switch to guava jre flavor

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -124,7 +124,7 @@ repositories {
 dependencies {
   implementation 'com.google.protobuf:protobuf-gradle-plugin:0.9.4'
   implementation 'commons-lang:commons-lang:2.6'
-  runtimeOnly 'com.google.guava:guava:32.1.2-android'
+  runtimeOnly 'com.google.guava:guava:32.1.2-jre'
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -91,7 +91,7 @@ object Dependencies {
 
   object Runtime {
     val logback = "ch.qos.logback" % "logback-classic" % "1.2.11" % "runtime" // Eclipse 1.0
-    val guavaAndroid = "com.google.guava" % "guava" % "32.1.2-android" % "runtime"
+    val guava = "com.google.guava" % "guava" % "32.1.2-jre" % "runtime"
   }
 
   object Protobuf {
@@ -109,7 +109,7 @@ object Dependencies {
     Compile.scalapbCompilerPlugin,
     Protobuf.protobufJava, // or else scalapb pulls older version in transitively
     Compile.grpcProtobuf,
-    Runtime.guavaAndroid, // forces a newer version than grpc-protobuf defaults too
+    Runtime.guava, // forces a newer version than grpc-protobuf defaults too
     Test.scalaTest)
 
   val runtime = l ++= Seq(
@@ -119,7 +119,7 @@ object Dependencies {
     Compile.grpcCore,
     Compile.grpcStub % Provided, // comes from the generators
     Compile.grpcNettyShaded,
-    Runtime.guavaAndroid, // forces a newer version than grpc-core/grpc-protobuf default too
+    Runtime.guava, // forces a newer version than grpc-core/grpc-protobuf default too
     Compile.pekkoStream,
     Compile.pekkoHttpCore,
     Compile.pekkoHttp,
@@ -158,7 +158,7 @@ object Dependencies {
   val pluginTester = l ++= Seq(
     // usually automatically added by `suggestedDependencies`, which doesn't work with ReflectiveCodeGen
     Compile.grpcStub,
-    Runtime.guavaAndroid,
+    Runtime.guava,
     Compile.pekkoHttpCors,
     Compile.pekkoHttp,
     Test.scalaTest,


### PR DESCRIPTION
https://github.com/softwaremill/tapir/pull/3124 is a PR which adds `pekko-grpc` support to Tapir. We noticed that `pekko-grpc-sbt-plugin` forces the android guava flavor:
```scala
"com.google.guava" % "guava" % "32.1.2-android" % "runtime"
```
It's described in a comment, that this, in effect, `forces a newer version than grpc-protobuf defaults too`.

The issue with Android flavor is that it overrides guava used by `sbt-scalajs`, which fails the `fastops` step with errors like:
```
[info] Fast optimizing /home/runner/work/tapir/tapir/integrations/cats/target/js-3/tapir-cats-test-fastopt
[error] java.lang.NoSuchMethodError: 'java.util.stream.Collector com.google.common.collect.ImmutableList.toImmutableList()'
[error] 	at org.openqa.selenium.remote.server.DefaultDriverFactory.<clinit>(DefaultDriverFactory.java:78)
```

Switching back to the `jre` flavor in Tapir seems to fix the issue. 
Can this be the default flavor used by pekko-grpc, since version number is locked to 32.1.2 anyway?