### PR TITLE
Update Scala 3 to 3.3.2

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SCALA_VERSION: [2.12.18, 2.13.11, 3.3.1]
+        SCALA_VERSION: [2.12.18, 2.13.11, 3.3.2-RC1]
         JAVA_VERSION: [8, 11]
     steps:
       - name: Checkout

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -28,7 +28,7 @@ jobs:
           cp .jvmopts-ci .jvmopts
           sbt +publish
           sbt ++2.13.11! codegen/publish
-          sbt ++3.3.1! codegen/publish
+          sbt ++3.3.2-RC1! codegen/publish
         env:
           NEXUS_USER: ${{ secrets.NEXUS_USER }}
           NEXUS_PW: ${{ secrets.NEXUS_PW }}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     // Update the .github workflows when these scala versions change
     val scala212 = "2.12.18"
     val scala213 = "2.13.11"
-    val scala3 = "3.3.1"
+    val scala3 = "3.3.2-RC1"
 
     // the order in the list is important because the head will be considered the default.
     val CrossScalaForLib = Seq(scala212, scala213, scala3)


### PR DESCRIPTION
Scala 3.3.2-RC1 just came out so this PR is testing it out to see if the codebase compiles. It will remain in draft until full release of Scala 3.3.2 is out.