### PR TITLE
Revert "[Netty] Fix client with TLS and custom SSL context"

### DIFF
--- a/runtime/src/main/scala/org/apache/pekko/grpc/internal/NettyClientUtils.scala
+++ b/runtime/src/main/scala/org/apache/pekko/grpc/internal/NettyClientUtils.scala
@@ -184,7 +184,6 @@ object NettyClientUtils {
   private def createNettySslContext(javaSslContext: SSLContext): SslContext = {
     import io.grpc.netty.shaded.io.netty.handler.ssl.{
       ApplicationProtocolConfig,
-      ApplicationProtocolNames,
       ClientAuth,
       IdentityCipherSuiteFilter,
       JdkSslContext
@@ -196,12 +195,8 @@ object NettyClientUtils {
       /* boolean isClient */ true,
       /* Iterable<String> ciphers */ null, // use JDK defaults (null is accepted as indicated in constructor Javadoc)
       IdentityCipherSuiteFilter.INSTANCE,
-      new ApplicationProtocolConfig(
-        ApplicationProtocolConfig.Protocol.ALPN,
-        ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
-        ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
-        ApplicationProtocolNames.HTTP_2),
-      ClientAuth.OPTIONAL, // server-only option, which is ignored as isClient=true (as indicated in constructor Javadoc)
+      /* ApplicationProtocolConfig apn */ ApplicationProtocolConfig.DISABLED, // use JDK default (null would also be acceptable, DISABLED config will select the NONE protocol and thus the JdkDefaultApplicationProtocolNegotiator)
+      ClientAuth.NONE, // server-only option, which is ignored as isClient=true (as indicated in constructor Javadoc)
       /* String[] protocols */ null, // use JDK defaults (null is accepted as indicated in constructor Javadoc)
       /* boolean startTls */ false)
   }


### PR DESCRIPTION
Reverts apache/incubator-pekko-grpc#197

the OP of apache/incubator-pekko-grpc#197 copied license incompatible code from akka-grpc - completely unacceptable

the code might be short but the OP kept the comments exactly the same as the akka comments making it obvious that the code is not his

Pekko contributors - anyone else who reads the akka-grpc code will become unavailable to review or contribute to fixing the original issue

We need a clean room fix.