### PR TITLE
Use lazy val in build for zero args defs plus sbt dsl

### DIFF
--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -21,10 +21,10 @@ import org.apache.commons.lang3.StringUtils
 object CopyrightHeader extends AutoPlugin {
   import HeaderPlugin.autoImport._
 
-  override def requires = HeaderPlugin
-  override def trigger = allRequirements
+  override lazy val requires = HeaderPlugin
+  override lazy val trigger = allRequirements
 
-  override def projectSettings =
+  override lazy val projectSettings =
     Def.settings(Seq(Compile, Test).flatMap { config =>
       inConfig(config)(
         Seq(
@@ -130,7 +130,6 @@ object CopyrightHeader extends AutoPlugin {
   private def isLightbendCopyrighted(text: String): Boolean =
     StringUtils.containsIgnoreCase(text, "lightbend inc.")
 
-  private def isOnlyLightbendCopyrightAnnotated(text: String): Boolean = {
+  private def isOnlyLightbendCopyrightAnnotated(text: String): Boolean =
     isLightbendCopyrighted(text) && !isApacheCopyrighted(text)
-  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -103,16 +103,16 @@ object Dependencies {
     val sbtProtoc = "com.thesamet" % "sbt-protoc" % BuildInfo.sbtProtocVersion
   }
 
-  private val l = libraryDependencies
+  private lazy val l = libraryDependencies
 
-  val codegen = l ++= Seq(
+  lazy val codegen = l ++= Seq(
     Compile.scalapbCompilerPlugin,
     Protobuf.protobufJava, // or else scalapb pulls older version in transitively
     Compile.grpcProtobuf,
     Runtime.guavaAndroid, // forces a newer version than grpc-protobuf defaults too
     Test.scalaTest)
 
-  val runtime = l ++= Seq(
+  lazy val runtime = l ++= Seq(
     Compile.scalapbRuntime,
     Protobuf.protobufJava, // or else scalapb pulls older version in transitively
     Compile.grpcProtobuf,
@@ -131,7 +131,7 @@ object Dependencies {
     Test.scalaTest,
     Test.scalaTestPlusJunit)
 
-  val mavenPlugin = l ++= Seq(
+  lazy val mavenPlugin = l ++= Seq(
     Compile.slf4jApi,
     Compile.mavenPluginApi,
     Compile.mavenCore,
@@ -139,12 +139,12 @@ object Dependencies {
     Compile.plexusBuildApi,
     Test.scalaTest)
 
-  val sbtPlugin = Seq(
+  lazy val sbtPlugin = Seq(
     l += Compile.scalapbCompilerPlugin,
     // we depend on it in the settings of the plugin since we set keys of the sbt-protoc plugin
     addSbtPlugin(Plugins.sbtProtoc))
 
-  val interopTests = l ++= Seq(
+  lazy val interopTests = l ++= Seq(
     Compile.grpcInteropTesting,
     Compile.grpcInteropTesting % "protobuf", // gets the proto files for interop tests
     Compile.pekkoHttp,
@@ -155,7 +155,7 @@ object Dependencies {
     Test.pekkoTestkit,
     Test.pekkoStreamTestkit)
 
-  val pluginTester = l ++= Seq(
+  lazy val pluginTester = l ++= Seq(
     // usually automatically added by `suggestedDependencies`, which doesn't work with ReflectiveCodeGen
     Compile.grpcStub,
     Runtime.guavaAndroid,

--- a/project/NoPublish.scala
+++ b/project/NoPublish.scala
@@ -24,8 +24,8 @@ import sbt.Keys._
  * For projects that are not to be published.
  */
 object NoPublish extends AutoPlugin {
-  override def requires = plugins.JvmPlugin
+  override lazy val requires = plugins.JvmPlugin
 
-  override def projectSettings =
+  override lazy val projectSettings =
     Seq(publish / skip := true, Compile / doc / sources := Seq.empty)
 }

--- a/project/ReflectiveCodeGen.scala
+++ b/project/ReflectiveCodeGen.scala
@@ -24,16 +24,16 @@ import protocbridge.{ Artifact => BridgeArtifact }
 
 /** A plugin that allows to use a code generator compiled in one subproject to be used in a test project */
 object ReflectiveCodeGen extends AutoPlugin {
-  val generatedLanguages = SettingKey[Seq[String]]("reflectiveGrpcGeneratedLanguages")
-  val generatedSources = SettingKey[Seq[String]]("reflectiveGrpcGeneratedSources")
-  val extraGenerators = SettingKey[Seq[String]]("reflectiveGrpcExtraGenerators")
-  val codeGeneratorSettings = settingKey[Seq[String]]("Code generator settings")
-  val protocOptions = settingKey[Seq[String]]("Protoc Options.")
+  lazy val generatedLanguages = SettingKey[Seq[String]]("reflectiveGrpcGeneratedLanguages")
+  lazy val generatedSources = SettingKey[Seq[String]]("reflectiveGrpcGeneratedSources")
+  lazy val extraGenerators = SettingKey[Seq[String]]("reflectiveGrpcExtraGenerators")
+  lazy val codeGeneratorSettings = settingKey[Seq[String]]("Code generator settings")
+  lazy val protocOptions = settingKey[Seq[String]]("Protoc Options.")
 
   // needed to be able to override the PB.generate task reliably
-  override def requires = ProtocPlugin
+  override lazy val requires = ProtocPlugin
 
-  override def projectSettings: Seq[Def.Setting[_]] =
+  override lazy val projectSettings: Seq[Def.Setting[_]] =
     inConfig(Compile)(
       Seq(
         PB.protocOptions := protocOptions.value,
@@ -93,7 +93,7 @@ object ReflectiveCodeGen extends AutoPlugin {
       watchSources ++= (ProjectRef(file("."), "codegen") / watchSources).value,
       watchSources ++= (ProjectRef(file("."), "sbt-plugin") / watchSources).value)
 
-  val setCodeGenerator = taskKey[Unit]("grpc-set-code-generator")
+  lazy val setCodeGenerator = taskKey[Unit]("grpc-set-code-generator")
 
   def loadAndSetGenerator(
       classpath: Classpath,
@@ -146,7 +146,7 @@ object ReflectiveCodeGen extends AutoPlugin {
     targets ++= generators.asInstanceOf[Seq[Target]]
   }
 
-  def generateTaskFromProtocPlugin: Def.Initialize[Task[Seq[File]]] =
+  lazy val generateTaskFromProtocPlugin: Def.Initialize[Task[Seq[File]]] =
     // lookup and return `PB.generate := ...` setting from ProtocPlugin
     ProtocPlugin.projectSettings
       .find(_.key.key == PB.generate.key)

--- a/project/SbtMavenPlugin.scala
+++ b/project/SbtMavenPlugin.scala
@@ -22,19 +22,19 @@ import scala.xml.{ Elem, PrettyPrinter, XML }
  * Inspired by https://github.com/lagom/lagom/blob/master/project/SbtMavenPlugin.scala
  */
 object SbtMavenPlugin extends AutoPlugin {
-  override def trigger = noTrigger
+  override lazy val trigger = noTrigger
 
-  override def requires = JvmPlugin
+  override lazy val requires = JvmPlugin
 
   object autoImport {
-    val mavenGeneratePluginXml = taskKey[Seq[File]]("Generate the maven plugin xml")
+    lazy val mavenGeneratePluginXml = taskKey[Seq[File]]("Generate the maven plugin xml")
   }
 
   import autoImport._
 
-  override def projectSettings: Seq[Setting[_]] = inConfig(Compile)(unscopedSettings)
+  override lazy val projectSettings: Seq[Setting[_]] = inConfig(Compile)(unscopedSettings)
 
-  def unscopedSettings =
+  lazy val unscopedSettings =
     Seq(
       (mavenGeneratePluginXml / sourceDirectory) := sourceDirectory.value / "maven",
       (mavenGeneratePluginXml / sources) :=

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -17,7 +17,7 @@ import sbt._
  */
 object VersionGenerator {
 
-  val settings: Seq[Setting[_]] = inConfig(Compile)(
+  lazy val settings: Seq[Setting[_]] = inConfig(Compile)(
     Seq(
       resourceGenerators += generateVersion(resourceManaged, _ / "pekko-grpc-version.conf",
         """|pekko.grpc.version = "%s"


### PR DESCRIPTION
Should improve the sbt build speed a little bit by avoiding unnecessary computation